### PR TITLE
[Security Solution] Fix code scanning alert

### DIFF
--- a/packages/kbn-cell-actions/src/actions/copy_to_clipboard/copy_to_clipboard.ts
+++ b/packages/kbn-cell-actions/src/actions/copy_to_clipboard/copy_to_clipboard.ts
@@ -33,7 +33,7 @@ const COPY_TO_CLIPBOARD_SUCCESS = i18n.translate(
   }
 );
 
-const escapeValue = (value: string) => value.replace(/"/g, '\\"');
+const escapeValue = (value: string) => value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 
 export const createCopyToClipboardActionFactory = createCellActionFactory(
   ({ notifications }: { notifications: NotificationsStart }) => ({


### PR DESCRIPTION
Fixes [https://github.com/elastic/kibana/security/code-scanning/365](https://github.com/elastic/kibana/security/code-scanning/365)

## Summary

To fix the problem, we need to ensure that both double quotes and backslashes are properly escaped in the `escapeValue` function. This can be achieved by using a regular expression that replaces both characters globally. Specifically, we should replace backslashes with double backslashes (`\\`) and double quotes with escaped double quotes (`\"`).

- Update the `escapeValue` function to use a regular expression that handles both double quotes and backslashes.
- Ensure that the regular expression has the global flag (`g`) to replace all occurrences of the characters.
